### PR TITLE
Cast to mute Xcode warning

### DIFF
--- a/RTMethod.m
+++ b/RTMethod.m
@@ -135,7 +135,7 @@
 
 - (NSUInteger)hash
 {
-    return (NSUInteger)[self selector] ^ (NSUInteger)[self implementation] ^ [[self signature] hash];
+    return (NSUInteger)(void *)[self selector] ^ (NSUInteger)[self implementation] ^ [[self signature] hash];
 }
 
 - (SEL)selector


### PR DESCRIPTION
Xcode 4.6 complains that we shouldn't cast a SEL to a NSUInteger in the hash method in RTMethod.m.  This fixes stops that warning with an intermediate cast to void \*  
